### PR TITLE
Card level caching

### DIFF
--- a/frontend/src/metabase-lib/lib/Question.js
+++ b/frontend/src/metabase-lib/lib/Question.js
@@ -135,6 +135,7 @@ export default class Question {
     dataset_query = type === "native"
       ? NATIVE_QUERY_TEMPLATE
       : STRUCTURED_QUERY_TEMPLATE,
+    cache_ttl,
   }: {
     databaseId?: DatabaseId,
     tableId?: TableId,
@@ -145,6 +146,7 @@ export default class Question {
     display?: string,
     visualization_settings?: VisualizationSettings,
     dataset_query?: DatasetQuery,
+    cache_ttl?: number,
   } = {}) {
     // $FlowFixMe
     let card: Card = {

--- a/frontend/src/metabase-types/types/Card.js
+++ b/frontend/src/metabase-types/types/Card.js
@@ -29,6 +29,7 @@ export type Card = {
   parameters?: Array<Parameter>,
   can_write: boolean,
   public_uuid: string,
+  cache_ttl: number,
 
   // Not part of the card API contract, a field used by query builder for showing lineage
   original_card_id?: CardId,

--- a/frontend/src/metabase/containers/SaveQuestionModal.jsx
+++ b/frontend/src/metabase/containers/SaveQuestionModal.jsx
@@ -158,6 +158,7 @@ export default class SaveQuestionModal extends Component {
                     <FormField
                       name="cache_ttl"
                       title={t`Cache TTL Multiplier`}
+                      type="input"
                       placeholder={t`Optionally override the default cache settings (ooh, fancy!)`}
                     />
                   </div>

--- a/frontend/src/metabase/containers/SaveQuestionModal.jsx
+++ b/frontend/src/metabase/containers/SaveQuestionModal.jsx
@@ -60,9 +60,9 @@ export default class SaveQuestionModal extends Component {
           ? originalCard.cache_ttl
           : !details.cache_ttl // check if blank, since field is optional
           ? null
-          : Number.isNaN(parseInt(details.cache_ttl)) // if non-int value
-          ? details.cache_ttl // send non-int to API
-          : parseInt(details.cache_ttl)
+          : details.cache_ttl.match(/[^$,.\d]/)  // if non-numeric value
+          ? details.cache_ttl // send non-numeric value and let API handle error
+          : parseFloat(details.cache_ttl) // else parse float and send to API (which will handle decimals)
     };
 
     if (details.saveType === "create") {

--- a/frontend/src/metabase/containers/SaveQuestionModal.jsx
+++ b/frontend/src/metabase/containers/SaveQuestionModal.jsx
@@ -55,6 +55,13 @@ export default class SaveQuestionModal extends Component {
         details.saveType === "overwrite"
           ? originalCard.collection_id
           : details.collection_id,
+      // since cache_ttl is optional, it can be null, so check for a value before trimming it
+      cache_ttl:
+        details.saveType === "overwrite"
+          ? originalCard.cache_ttl
+          : details.cache_ttl
+          ? details.cache_ttl.trim()
+          : null,
     };
 
     if (details.saveType === "create") {
@@ -107,6 +114,7 @@ export default class SaveQuestionModal extends Component {
             { name: "name" },
             { name: "description" },
             { name: "collection_id" },
+            { name: "cache_ttl" },
           ]}
           onSubmit={this.handleSubmit}
         >
@@ -146,6 +154,11 @@ export default class SaveQuestionModal extends Component {
                       name="collection_id"
                       title={t`Which collection should this go in?`}
                       type="collection"
+                    />
+                    <FormField
+                      name="cache_ttl"
+                      title={t`Cache TTL Multiplier`}
+                      placeholder={t`Optionally override the default cache settings (ooh, fancy!)`}
                     />
                   </div>
                 )}

--- a/frontend/src/metabase/containers/SaveQuestionModal.jsx
+++ b/frontend/src/metabase/containers/SaveQuestionModal.jsx
@@ -60,9 +60,9 @@ export default class SaveQuestionModal extends Component {
           ? originalCard.cache_ttl
           : !details.cache_ttl // check if blank, since field is optional
           ? null
-          : details.cache_ttl.match(/[^$,.\d]/)  // if non-numeric value
+          : details.cache_ttl.match(/[^$,.\d]/) // if non-numeric value
           ? details.cache_ttl // send non-numeric value and let API handle error
-          : parseFloat(details.cache_ttl) // else parse float and send to API (which will handle decimals)
+          : parseFloat(details.cache_ttl), // else parse float and send to API (which will handle decimals)
     };
 
     if (details.saveType === "create") {

--- a/frontend/src/metabase/containers/SaveQuestionModal.jsx
+++ b/frontend/src/metabase/containers/SaveQuestionModal.jsx
@@ -160,7 +160,7 @@ export default class SaveQuestionModal extends Component {
                       name="cache_ttl"
                       title={t`Cache TTL Multiplier`}
                       type="input"
-                      placeholder={t`Optionally override the default cache settings (ooh, fancy!)`}
+                      placeholder={t`Query time (sec) * TTL Multiplier = time your query result stays cached`}
                     />
                   </div>
                 )}

--- a/frontend/src/metabase/containers/SaveQuestionModal.jsx
+++ b/frontend/src/metabase/containers/SaveQuestionModal.jsx
@@ -37,7 +37,6 @@ export default class SaveQuestionModal extends Component {
     //     .setDescription(details.description ? details.description.trim() : null)
     //     .setCollectionId(details.collection_id)
     let { card, originalCard, onCreate, onSave } = this.props;
-
     card = {
       ...card,
       name:
@@ -55,13 +54,15 @@ export default class SaveQuestionModal extends Component {
         details.saveType === "overwrite"
           ? originalCard.collection_id
           : details.collection_id,
-      // since cache_ttl is optional, it can be null, so check for a value before trimming it
+      // cache_ttl is also optional, but pass non-int values to the API so it can handle the error
       cache_ttl:
         details.saveType === "overwrite"
           ? originalCard.cache_ttl
-          : details.cache_ttl
-          ? details.cache_ttl.trim()
-          : null,
+          : !details.cache_ttl // check if blank, since field is optional
+          ? null
+          : Number.isNaN(parseInt(details.cache_ttl)) // if non-int value
+          ? details.cache_ttl // send non-int to API
+          : parseInt(details.cache_ttl)
     };
 
     if (details.saveType === "create") {

--- a/frontend/src/metabase/entities/questions.js
+++ b/frontend/src/metabase/entities/questions.js
@@ -106,6 +106,11 @@ const Questions = createEntity({
           type: "text",
           placeholder: t`It's optional but oh, so helpful`,
         },
+        {
+          name: "cache_ttl",
+          title: t`Cache TTL Multiplier`,
+          placeholder: t`Optionally override the default cache settings (ooh, fancy!)`,
+        },
       ],
     },
   },

--- a/frontend/src/metabase/entities/questions.js
+++ b/frontend/src/metabase/entities/questions.js
@@ -129,6 +129,7 @@ const Questions = createEntity({
     "collection_position",
     "result_metadata",
     "metadata_checksum",
+    "cache_ttl",
   ],
 
   getAnalyticsMetadata([object], { action }, getState) {

--- a/frontend/src/metabase/entities/questions.js
+++ b/frontend/src/metabase/entities/questions.js
@@ -109,7 +109,7 @@ const Questions = createEntity({
         {
           name: "cache_ttl",
           title: t`Cache TTL Multiplier`,
-          placeholder: t`Optionally override the default cache settings (ooh, fancy!)`,
+          placeholder: t`Query time (sec) * TTL Multiplier = time your query result stays cached`,
         },
       ],
     },

--- a/frontend/src/metabase/lib/settings.js
+++ b/frontend/src/metabase/lib/settings.js
@@ -25,6 +25,7 @@ export type SettingName =
   | "ldap-configured?"
   | "map-tile-server-url"
   | "password-complexity"
+  | "query-caching-ttl-ratio"
   | "setup-token"
   | "site-url"
   | "types"

--- a/frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx
+++ b/frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx
@@ -15,6 +15,13 @@ const EditQuestionInfoModal = ({ question, onClose, onSave }) => (
       submitTitle={t`Save`}
       onClose={onClose}
       onSubmit={async card => {
+        // if cache_ttl is not an integer, pass it to the API and let it handle the error
+        card.cache_ttl = 
+          !card.cache_ttl // if blank
+            ? null
+            : Number.isNaN(parseInt(card.cache_ttl)) // if non-int value
+            ? card.cache_ttl
+            : parseInt(card.cache_ttl) // else parse int value
         await onSave({ ...question.card(), ...card });
         onClose();
       }}

--- a/frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx
+++ b/frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx
@@ -18,10 +18,10 @@ const EditQuestionInfoModal = ({ question, onClose, onSave }) => (
         // if cache_ttl is not an integer, pass it to the API and let it handle the error
         card.cache_ttl = 
           !card.cache_ttl // if blank
-            ? null
-            : Number.isNaN(parseInt(card.cache_ttl)) // if non-int value
-            ? card.cache_ttl
-            : parseInt(card.cache_ttl) // else parse int value
+            ? null // send null
+            : card.cache_ttl.match(/[^$,.\d]/) // if non-numeric value
+            ? card.cache_ttl // send non-numeric value and let API handle error
+            : parseFloat(card.cache_ttl) // else parse float and send to API (which will handle decimals)
         await onSave({ ...question.card(), ...card });
         onClose();
       }}

--- a/frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx
+++ b/frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx
@@ -16,12 +16,11 @@ const EditQuestionInfoModal = ({ question, onClose, onSave }) => (
       onClose={onClose}
       onSubmit={async card => {
         // if cache_ttl is not an integer, pass it to the API and let it handle the error
-        card.cache_ttl = 
-          !card.cache_ttl // if blank
-            ? null // send null
-            : card.cache_ttl.match(/[^$,.\d]/) // if non-numeric value
-            ? card.cache_ttl // send non-numeric value and let API handle error
-            : parseFloat(card.cache_ttl) // else parse float and send to API (which will handle decimals)
+        card.cache_ttl = !card.cache_ttl // if blank
+          ? null // send null
+          : card.cache_ttl.match(/[^$,.\d]/) // if non-numeric value
+          ? card.cache_ttl // send non-numeric value and let API handle error
+          : parseFloat(card.cache_ttl); // else parse float and send to API (which will handle decimals)
         await onSave({ ...question.card(), ...card });
         onClose();
       }}

--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -26,6 +26,7 @@
             [metabase.driver.sql.query-processor :as sql.qp]
             [metabase.driver.sql.util.unprepare :as unprepare]
             [metabase.query-processor.store :as qp.store]
+            [metabase.query-processor.middleware.format-rows :as format-rows]
             [metabase.util
              [date-2 :as u.date]
              [honeysql-extensions :as hx]
@@ -300,6 +301,16 @@
   (format "timestamp '%s'" (u.date/format value)))
 
 (prefer-method unprepare/unprepare-value [:sql Time] [:snowflake Date])
+
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                         FormatValue protocol overrides impls                                   |
+;;; +----------------------------------------------------------------------------------------------------------------+
+;; Overrides how specific types are formatted when serializing query results
+
+(extend-protocol format-rows/FormatValue
+  java.time.LocalDate
+  (format-value [t _] t)
+)
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                         metabase.driver.sql-jdbc.execute impls                                 |

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -242,7 +242,7 @@
 (api/defendpoint ^:returns-chan POST "/"
   "Create a new `Card`."
   [:as {{:keys [collection_id collection_position dataset_query description display metadata_checksum name
-                result_metadata visualization_settings], :as body} :body}]
+                result_metadata visualization_settings cache_ttl], :as body} :body}]
   {name                   su/NonBlankString
    description            (s/maybe su/NonBlankString)
    display                su/NonBlankString
@@ -250,7 +250,8 @@
    collection_id          (s/maybe su/IntGreaterThanZero)
    collection_position    (s/maybe su/IntGreaterThanZero)
    result_metadata        (s/maybe qr/ResultsMetadata)
-   metadata_checksum      (s/maybe su/NonBlankString)}
+   metadata_checksum      (s/maybe su/NonBlankString)
+   cache_ttl              (s/maybe su/IntGreaterThanZero)}
   ;; check that we have permissions to run the query that we're trying to save
   (check-data-permissions-for-query dataset_query)
   ;; check that we have permissions for the collection we're trying to save this card to, if applicable
@@ -420,7 +421,8 @@
 (api/defendpoint ^:returns-chan PUT "/:id"
   "Update a `Card`."
   [id :as {{:keys [dataset_query description display name visualization_settings archived collection_id
-                   collection_position enable_embedding embedding_params result_metadata metadata_checksum]
+                   collection_position enable_embedding embedding_params result_metadata metadata_checksum
+                   cache_ttl]
             :as   card-updates} :body}]
   {name                   (s/maybe su/NonBlankString)
    dataset_query          (s/maybe su/Map)
@@ -433,7 +435,8 @@
    collection_id          (s/maybe su/IntGreaterThanZero)
    collection_position    (s/maybe su/IntGreaterThanZero)
    result_metadata        (s/maybe qr/ResultsMetadata)
-   metadata_checksum      (s/maybe su/NonBlankString)}
+   metadata_checksum      (s/maybe su/NonBlankString)
+   cache_ttl              (s/maybe su/IntGreaterThanZero)}
   (let [card-before-update (api/write-check Card id)]
     ;; Do various permissions checks
     (collection/check-allowed-to-change-collection card-before-update card-updates)

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -220,7 +220,7 @@
   ;; `zipmap` instead of `select-keys` because we want to get `nil` values for keys that aren't present. Required by
   ;; `api/maybe-reconcile-collection-position!`
   (let [data-keys            [:dataset_query :description :display :name
-                              :visualization_settings :collection_id :collection_position]
+                              :visualization_settings :collection_id :collection_position :cache_ttl]
         card-data            (assoc (zipmap data-keys (map card-data data-keys))
                                     :creator_id api/*current-user-id*)
         result-metadata-chan (result-metadata-async dataset_query result_metadata metadata_checksum)
@@ -409,7 +409,7 @@
         (u/select-keys-when card-updates
           :present #{:collection_id :collection_position :description}
           :non-nil #{:dataset_query :display :name :visualization_settings :archived :enable_embedding
-                     :embedding_params :result_metadata})))
+                     :embedding_params :result_metadata :cache_ttl})))
     ;; Fetch the updated Card from the DB
     (let [card (Card id)]
       (delete-alerts-if-needed! card-before-update card)


### PR DESCRIPTION
Adding support for card-level caching, as requested in [this Jira ticket](https://convoy.atlassian.net/browse/DATA-837) and this [Metabase Github issue](https://github.com/metabase/metabase/issues/10745#issuecomment-525872413).

Makes use of existing back-end infrastructure for setting cache-ttt value per card. Updates the save and edit card APIs to pass this value in, and adds a box in the save/edit UI forms for people to specify a value.
